### PR TITLE
ci: fix github cache logic to pull from buildharness release

### DIFF
--- a/.github/actions/autoformat/action.yml
+++ b/.github/actions/autoformat/action.yml
@@ -16,6 +16,18 @@ inputs:
   github-context:
     description: The GitHub Status Context to use when updating the status
     required: true
+  buildharness_version:
+    description: The version of buildharness used by the caller repo
+    required: true
+  golang_version:
+    description: The version of golang used by the buildharness release from the caller repo
+    required: true
+  terraform_version:
+    description: The version of terraform used by the buildharness release from the caller repo
+    required: true
+  zarf_version:
+    description: The version of zarf used by the buildharness release from the caller repo
+    required: true
 
 runs:
   using: composite
@@ -51,40 +63,30 @@ runs:
         repository: ${{ github.event.client_payload.pull_request.head.repo.full_name || github.repository }}
         ref: ${{ github.event.client_payload.pull_request.head.ref || github.ref }}
 
-    - name: Get versions of relevant tools for github cache
-      id: get_tool_versions
-      shell: bash -e -o pipefail {0}
-      run: |
-        echo "TF_VERSION=$(asdf list terraform | sed 's/\*//')" >> $GITHUB_OUTPUT
-        echo "GOLANG_VERSION=$(asdf list golang | sed 's/\*//')" >> $GITHUB_OUTPUT
-        echo "ZARF_VERSION=$(asdf list zarf | sed 's/\*//')" >> $GITHUB_OUTPUT
-        echo "BUILD_HARNESS_VERSION=$(grep BUILD_HARNESS_VERSION .env | awk -F'=' '{print $2}')" >> $GITHUB_OUTPUT
-
-
     - name: Init gopath cache
       uses: actions/cache@v3
       with:
         path: "${{ github.workspace }}/.cache/go"
-        key: "gopath|${{ steps.get_tool_versions.outputs.GOLANG_VERSION }}|${{ hashFiles('go.sum') }}"
+        key: "gopath|${{ inputs.golang_version }}|${{ hashFiles('go.sum') }}"
 
     - name: Init gobuild cache
       uses: actions/cache@v3
       with:
         path: "${{ github.workspace }}/.cache/go-build"
-        key: "gobuild|${{ steps.get_tool_versions.outputs.GOLANG_VERSION }}|${{ hashFiles('go.sum') }}"
+        key: "gobuild|${{ inputs.golang_version }}|${{ hashFiles('go.sum') }}"
 
     - name: Init zarf cache
       uses: actions/cache@v3
       with:
         path: "${{ github.workspace }}/.cache/.zarf-cache"
-        key: "zarf|${{ steps.get_tool_versions.outputs.ZARF_VERSION }}"
+        key: "zarf|${{ inputs.zarf_version }}"
 
     - name: Init docker cache
       id: init-docker-cache
       uses: actions/cache@v3
       with:
         path: "${{ github.workspace }}/.cache/docker"
-        key: "docker|${{ steps.get_tool_versions.outputs.BUILD_HARNESS_VERSION }}"
+        key: "docker|${{ inputs.buildharness_version }}"
 
     - name: Docker save build harness
       if: steps.init-docker-cache.outputs.cache-hit != 'true'
@@ -101,7 +103,7 @@ runs:
       uses: actions/cache@v3
       with:
         path: "${{ github.workspace }}/.cache/.terraform.d/plugin-cache"
-        key: "${{ runner.os }}-terraform-plugins|${{ steps.get_tool_versions.outputs.TF_VERSION }}|${{ hashFiles('examples/complete/providers.tf') }}"
+        key: "${{ runner.os }}-terraform-plugins|${{ inputs.terraform_version }}|${{ hashFiles('examples/complete/providers.tf') }}"
 
     - name: Update files with automatic formatting tools
       shell: bash -e -o pipefail {0}

--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -30,6 +30,19 @@ inputs:
   test-to-run:
     description: Which test to run, either "secure" or "insecure"
     required: true
+  buildharness_version:
+    description: The version of buildharness used by the caller repo
+    required: true
+  golang_version:
+    description: The version of golang used by the buildharness release from the caller repo
+    required: true
+  terraform_version:
+    description: The version of terraform used by the buildharness release from the caller repo
+    required: true
+  zarf_version:
+    description: The version of zarf used by the buildharness release from the caller repo
+    required: true
+
 
 runs:
   using: composite
@@ -74,40 +87,30 @@ runs:
         repository: ${{ github.event.client_payload.pull_request.head.repo.full_name || github.repository }}
         ref: ${{ github.event.client_payload.pull_request.head.ref || github.ref_name }}
 
-    - name: Get versions of relevant tools for github cache
-      id: get_tool_versions
-      shell: bash -e -o pipefail {0}
-      run: |
-        echo "TF_VERSION=$(asdf list terraform | sed 's/\*//')" >> $GITHUB_OUTPUT
-        echo "GOLANG_VERSION=$(asdf list golang | sed 's/\*//')" >> $GITHUB_OUTPUT
-        echo "ZARF_VERSION=$(asdf list zarf | sed 's/\*//')" >> $GITHUB_OUTPUT
-        echo "BUILD_HARNESS_VERSION=$(grep BUILD_HARNESS_VERSION .env | awk -F'=' '{print $2}')" >> $GITHUB_OUTPUT
-
-
     - name: Init gopath cache
       uses: actions/cache@v3
       with:
         path: "${{ github.workspace }}/.cache/go"
-        key: "gopath|${{ steps.get_tool_versions.outputs.GOLANG_VERSION }}|${{ hashFiles('go.sum') }}"
+        key: "gopath|${{ inputs.golang_version }}|${{ hashFiles('go.sum') }}"
 
     - name: Init gobuild cache
       uses: actions/cache@v3
       with:
         path: "${{ github.workspace }}/.cache/go-build"
-        key: "gobuild|${{ steps.get_tool_versions.outputs.GOLANG_VERSION }}|${{ hashFiles('go.sum') }}"
+        key: "gobuild|${{ inputs.golang_version }}|${{ hashFiles('go.sum') }}"
 
     - name: Init zarf cache
       uses: actions/cache@v3
       with:
         path: "${{ github.workspace }}/.cache/.zarf-cache"
-        key: "zarf|${{ steps.get_tool_versions.outputs.ZARF_VERSION }}"
+        key: "zarf|${{ inputs.zarf_version }}"
 
     - name: Init docker cache
       id: init-docker-cache
       uses: actions/cache@v3
       with:
         path: "${{ github.workspace }}/.cache/docker"
-        key: "docker|${{ steps.get_tool_versions.outputs.BUILD_HARNESS_VERSION }}"
+        key: "docker|${{ inputs.buildharness_version }}"
 
     - name: Docker save build harness
       if: steps.init-docker-cache.outputs.cache-hit != 'true'
@@ -124,7 +127,7 @@ runs:
       uses: actions/cache@v3
       with:
         path: "${{ github.workspace }}/.cache/.terraform.d/plugin-cache"
-        key: "${{ runner.os }}-terraform-plugins|${{ steps.get_tool_versions.outputs.TF_VERSION }}|${{ hashFiles('examples/complete/providers.tf') }}"
+        key: "${{ runner.os }}-terraform-plugins|${{ inputs.terraform_version }}|${{ hashFiles('examples/complete/providers.tf') }}"
 
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4

--- a/.github/actions/get-buildharness-software-versions/action.yml
+++ b/.github/actions/get-buildharness-software-versions/action.yml
@@ -1,0 +1,60 @@
+name: Get buildharness software versions
+
+description: This action gets the versions of the tools used by buildharness and outputs them as environment variables.
+
+inputs:
+  # either pass in a token, or an app id and private key, only needed for private repos
+  token:
+    description: 'The GitHub token to use for authentication'
+    required: false
+  application_id:
+    description: 'The GitHub App ID'
+    required: false
+  application_private_key:
+    description: 'The GitHub App private key'
+    required: false
+
+outputs:
+  buildharness_version:
+    description: The version of buildharness used by the caller repo
+    value: ${{ steps.tool-versions.outputs.BUILD_HARNESS_VERSION }}
+  golang_version:
+    description: The version of golang used by buildharness
+    value: ${{ steps.tool-versions.outputs.GOLANG_VERSION }}
+  terraform_version:
+    description: The version of terraform used by buildharness
+    value: ${{ steps.tool-versions.outputs.TF_VERSION }}
+  zarf_version:
+    description: The version of zarf used by buildharness
+    value: ${{ steps.tool-versions.outputs.ZARF_VERSION }}
+
+runs:
+  using: composite
+  steps:
+    - name: Get token
+      id: get_installation_token
+      uses: peter-murray/workflow-application-token-action@v2
+      if: ${{ !inputs.token }}
+      with:
+        application_id: ${{ inputs.application_id }}
+        application_private_key: ${{ inputs.application_private_key }}
+
+    - name: Checkout repo to get buildharness version
+      uses: actions/checkout@v4
+      with:
+        token: ${{ inputs.token || steps.get_installation_token.outputs.token }}
+        repository: ${{ github.event.client_payload.pull_request.head.repo.full_name || github.repository }}
+        ref: ${{ github.event.client_payload.pull_request.head.ref || github.ref }}
+
+    - name: Get .tool-versions file using curl, and set outputs
+      shell: bash -e -o pipefail {0}
+      id: tool-versions
+      run: |
+        BUILD_HARNESS_VERSION=$(grep BUILD_HARNESS_VERSION .env | awk -F'=' '{print $2}')
+        echo "BUILD_HARNESS_VERSION=$BUILD_HARNESS_VERSION" >> $GITHUB_OUTPUT
+
+        TOOL_VERSIONS=$(curl -SsL --retry 3 https://raw.githubusercontent.com/defenseunicorns/build-harness/$BUILD_HARNESS_VERSION/.tool-versions)
+        echo GOLANG_VERSION=$(grep -w 'golang' <<<"$TOOL_VERSIONS " | awk '{print $2}') >> $GITHUB_OUTPUT
+        echo TF_VERSION=$(grep -w 'terraform' <<<"$TOOL_VERSIONS " | awk '{print $2}') >> $GITHUB_OUTPUT
+        echo ZARF_VERSION=$(grep -w 'zarf' <<<"$TOOL_VERSIONS " | awk '{print $2}') >> $GITHUB_OUTPUT
+

--- a/.github/actions/pre-commit/action.yml
+++ b/.github/actions/pre-commit/action.yml
@@ -17,6 +17,12 @@ inputs:
     description: The type of check to run. Valid values are "all", "common", "terraform", "golang", and "renovate"
     required: true
     default: all
+  buildharness_version:
+    description: The version of buildharness used by the caller repo
+    required: true
+  golang_version:
+    description: The version of golang used by the buildharness release from the caller repo
+    required: true
 
 runs:
   using: composite
@@ -42,35 +48,24 @@ runs:
         path: "${{ github.workspace }}/.cache/pre-commit"
         key: "pre-commit-${{inputs.check-type}}|${{hashFiles('.pre-commit-config.yaml')}}"
 
-    - name: Get versions of relevant tools for github cache
-      id: get_tool_versions
-      shell: bash -e -o pipefail {0}
-      run: |
-        echo "TF_VERSION=$(asdf list terraform | sed 's/\*//')" >> $GITHUB_OUTPUT
-        echo "GOLANG_VERSION=$(asdf list golang | sed 's/\*//')" >> $GITHUB_OUTPUT
-        echo "ZARF_VERSION=$(asdf list zarf | sed 's/\*//')" >> $GITHUB_OUTPUT
-        echo "BUILD_HARNESS_VERSION=$(grep BUILD_HARNESS_VERSION .env | awk -F'=' '{print $2}')" >> $GITHUB_OUTPUT
-
     - name: Init gopath cache
-      if: inputs.check-type == 'golang' || inputs.check-type == 'all'
       uses: actions/cache@v3
       with:
         path: "${{ github.workspace }}/.cache/go"
-        key: "gopath|${{ steps.get_tool_versions.outputs.GOLANG_VERSION }}|${{ hashFiles('go.sum') }}"
+        key: "gopath|${{ inputs.golang_version }}|${{ hashFiles('go.sum') }}"
 
     - name: Init gobuild cache
-      if: inputs.check-type == 'golang' || inputs.check-type == 'all'
       uses: actions/cache@v3
       with:
         path: "${{ github.workspace }}/.cache/go-build"
-        key: "gobuild|${{ steps.get_tool_versions.outputs.GOLANG_VERSION }}|${{ hashFiles('go.sum') }}"
+        key: "gobuild|${{ inputs.golang_version }}|${{ hashFiles('go.sum') }}"
 
     - name: Init docker cache
       id: init-docker-cache
       uses: actions/cache@v3
       with:
         path: "${{ github.workspace }}/.cache/docker"
-        key: "docker|${{ steps.get_tool_versions.outputs.BUILD_HARNESS_VERSION }}"
+        key: "docker|${{ inputs.buildharness_version }}"
 
     - name: Docker save build harness
       if: steps.init-docker-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -40,9 +40,24 @@ jobs:
   comment:
     runs-on: ubuntu-latest
     steps:
-
       - name: Update Comment
         uses: defenseunicorns/delivery-github-actions-workflows/.github/actions/comment@main
+        with:
+          application_id: ${{ secrets.APPLICATION_ID }}
+          application_private_key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+          token: ${{ secrets.TOKEN }}
+
+  get-buildharness-software-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      buildharness_version: ${{ steps.buildharness_software_versions.outputs.buildharness_version }}
+      golang_version: ${{ steps.buildharness_software_versions.outputs.golang_version }}
+      terraform_version: ${{ steps.buildharness_software_versions.outputs.terraform_version }}
+      zarf_version: ${{ steps.buildharness_software_versions.outputs.zarf_version }}
+    steps:
+      - name: Get buildharness software versions
+        id: buildharness_software_versions
+        uses: defenseunicorns/delivery-github-actions-workflows/.github/actions/get-buildharness-software-versions@main
         with:
           application_id: ${{ secrets.APPLICATION_ID }}
           application_private_key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
@@ -54,7 +69,6 @@ jobs:
     needs: parse
     if: needs.parse.outputs.run-ping == 'true'
     steps:
-
       - name: Ping Test
         uses: defenseunicorns/delivery-github-actions-workflows/.github/actions/ping@main
         with:
@@ -65,7 +79,9 @@ jobs:
   # Run the E2E insecure tests on the commercial account
   e2e-commercial-insecure:
     runs-on: ubuntu-latest
-    needs: parse
+    needs:
+      - parse
+      - get-buildharness-software-versions
     if: needs.parse.outputs.run-e2e-commercial-insecure == 'true'
     steps:
       - name: Run E2E Tests
@@ -78,11 +94,18 @@ jobs:
           region: us-east-2
           github-context: "test / e2e-commercial-insecure"
           test-to-run: "insecure"
+          buildharness_version: ${{ needs.get-buildharness-software-versions.outputs.buildharness_version }}
+          golang_version: ${{ needs.get-buildharness-software-versions.outputs.golang_version }}
+          terraform_version: ${{ needs.get-buildharness-software-versions.outputs.terraform_version }}
+          zarf_version: ${{ needs.get-buildharness-software-versions.outputs.zarf_version }}
+
 
   # Run the E2E secure tests on the govcloud account
   e2e-govcloud-secure:
     runs-on: ubuntu-latest
-    needs: parse
+    needs:
+      - parse
+      - get-buildharness-software-versions
     if: needs.parse.outputs.run-e2e-govcloud-secure == 'true'
     steps:
       - name: Run E2E Tests
@@ -95,3 +118,8 @@ jobs:
           region: us-gov-east-1
           github-context: "test / e2e-govcloud-secure"
           test-to-run: "secure"
+          buildharness_version: ${{ needs.get-buildharness-software-versions.outputs.buildharness_version }}
+          golang_version: ${{ needs.get-buildharness-software-versions.outputs.golang_version }}
+          terraform_version: ${{ needs.get-buildharness-software-versions.outputs.terraform_version }}
+          zarf_version: ${{ needs.get-buildharness-software-versions.outputs.zarf_version }}
+

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -27,6 +27,13 @@ jobs:
       matrix:
         check-type: ${{ fromJSON(inputs.check-types) }}
     steps:
+      - name: Get buildharness software versions
+        id: buildharness_software_versions
+        uses: defenseunicorns/delivery-github-actions-workflows/.github/actions/get-buildharness-software-versions@main
+        with:
+          application_id: ${{ secrets.APPLICATION_ID }}
+          application_private_key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+          token: ${{ secrets.TOKEN }}
 
       - name: pre-commit
         uses: defenseunicorns/delivery-github-actions-workflows/.github/actions/pre-commit@main
@@ -35,3 +42,5 @@ jobs:
           application_id: ${{ secrets.APPLICATION_ID }}
           application_private_key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
           token: ${{ secrets.TOKEN }}
+          buildharness_version: ${{ steps.buildharness-software-versions.outputs.buildharness_version }}
+          golang_version: ${{ steps.buildharness-software-versions.outputs.golang_version }}

--- a/.github/workflows/renovate-test.yml
+++ b/.github/workflows/renovate-test.yml
@@ -49,15 +49,3 @@ jobs:
         with:
           token: ${{ secrets.token || steps.get_installation_token.outputs.token }}
           github-context: "update / autoformat"
-
-      - name: Wait 5 seconds
-        run: sleep 5
-
-      - name: Create comment
-        uses: peter-evans/create-or-update-comment@v3
-        with:
-          token: ${{ secrets.token || steps.get_installation_token.outputs.token }}
-          repository: ${{ github.repository }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            /test all

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -59,6 +59,13 @@ jobs:
     needs: parse
     if: needs.parse.outputs.run-autoformat == 'true'
     steps:
+      - name: Get buildharness software versions
+        id: buildharness_software_versions
+        uses: defenseunicorns/delivery-github-actions-workflows/.github/actions/get-buildharness-software-versions@main
+        with:
+          application_id: ${{ secrets.APPLICATION_ID }}
+          application_private_key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+          token: ${{ secrets.TOKEN }}
 
       - name: Autoformat
         uses: defenseunicorns/delivery-github-actions-workflows/.github/actions/autoformat@main
@@ -67,3 +74,8 @@ jobs:
           application_private_key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
           token: ${{ secrets.TOKEN }}
           github-context: "update / autoformat"
+          buildharness_version: ${{ steps.buildharness-software-versions.outputs.buildharness_version }}
+          golang_version: ${{ steps.buildharness-software-versions.outputs.golang_version }}
+          terraform_version: ${{ steps.buildharness-software-versions.outputs.terraform_version }}
+          zarf_version: ${{ steps.buildharness-software-versions.outputs.zarf_version }}
+


### PR DESCRIPTION
This is a pattern to use a new action to get the versions of the tools matching the buildharness version from the caller repo's .env file. This will determine the key for relevant caches